### PR TITLE
Added support for Tiny Tiny RSS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,9 @@ Detects following software
 * Serendipity: [Serendipity release advisory](http://blog.s9y.org/archives/247-Serendipity-1.7-released.html) [Security advisory](https://www.mavitunasecurity.com/xss-vulnerabilities-in-serendipity/)
 * TestLink: CVE-2012-2275 http://osvdb.org/84712 http://osvdb.org/84711 http://osvdb.org/84713
 * TikiWiki: CVE-2012-0911 OSVDB:83534, CVE-2012-3996 [OSVDB 83533](http://osvdb.org/83533)
+* Tiny Tiny RSS: SA43424 [OSVDB:70934](http://osvdb.org/70934)
 * Trac: CVE-2010-5108 [OSVDB 63317](http://osvdb.org/63317)
-* WikkaWiki: CVE-2011-4448, CVE-2011-4449, CVE-2011-4450, CVE-2011-4451, CVE-2011-4452 OSVDB 77390-77394 [WikkaWiki security advisory](http://blog.wikkawiki.org/2011/12/04/security-updates-for-1-3-11-3-2/) 
+* WikkaWiki: CVE-2011-4448, CVE-2011-4449, CVE-2011-4450, CVE-2011-4451, CVE-2011-4452 OSVDB 77390-77394 [WikkaWiki security advisory](http://blog.wikkawiki.org/2011/12/04/security-updates-for-1-3-11-3-2/)
 * WordPress: CVE-2013-2199, CVE-2013-2200, CVE-2013-2201, CVE-2013-2202, CVE-2013-2203, CVE-2013-2204, CVE-2013-2205, [WordPress News](http://wordpress.org/news/2013/06/wordpress-3-5-2/), [WordPress Codex](http://codex.wordpress.org/Version_3.5.2)
 * Zenphoto: http://www.waraxe.us/content-96.html http://osvdb.org/87015
 * e107: CVE-2012-6434 [OSVDB 88908](http://osvdb.org/88908)

--- a/yamls/tt-rss.yml
+++ b/yamls/tt-rss.yml
@@ -1,0 +1,10 @@
+# URL: http://tt-rss.org/
+# SA43424 http://osvdb.org/70934
+TinyTinyRSS:
+  1:
+    location: ['/include/version.php', '/version.php']
+    secure_version: '1.5.2'
+    regexp: ['\s*?define.*?VERSION.*?(?P<version>[0-9.]+)']
+    cve: SA43424 http://osvdb.org/70934
+    fingerprint: detect_general
+    post_processing: ['php5.fcgi']


### PR DESCRIPTION
Added fingerprints for detecting version of [Tiny Tiny RSS reader](http://tt-rss.org).

Secure version is determined from this fixed tt-rss issue http://tt-rss.org/redmine/issues/323 which was referenced from the only tt-rss specific advisory found from OSVDB.
