### PR TITLE
Fixed link to official Collabtive website

### DIFF
--- a/yamls/collabtive.yml
+++ b/yamls/collabtive.yml
@@ -1,4 +1,4 @@
-# URL: http://www.collabtive.com/
+# URL: http://collabtive.o-dyn.de/
 # CVE-2012-2670
 # CVE-2013-6872 1.2 http://osvdb.org/102123 http://secunia.com/advisories/56329/
 # CVE-2014-3246 2.0 http://osvdb.org/106764


### PR DESCRIPTION
The official website for Collabtive is NOT collabtive.com but http://collabtive.o-dyn.de/.

Disclaimer:
I am one of the lead devs of Collabtive.
The link you provide (collabtive.com) unfortunately leads to a company that tries to seem legit, but is not. The one-and-only official website for Collabtive is ours: http://collabtive.o-dyn.de

We would be very glad if you could accept this PR which changes the link to the correct resource, since the people from the other page are doing all sorts of bad stuff... I hope you understand. :)

Thank you!