### PR TITLE
Added osCommerce and sorted Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Detects following software
 * Dolibarr
 * Dotclear
 * Drupal
+* e107
 * EspoCRM
 * Etherpad
 * FlatPress
@@ -61,7 +62,12 @@ Detects following software
 * MyBB
 * Nibbleblog
 * OpenCart
+* osCommerce
+* osDate
+* ownCloud
 * PBBoard
+* phpBB3
+* phpMyAdmin
 * Piwigo
 * PmWiki
 * Roundcube
@@ -79,11 +85,6 @@ Detects following software
 * Zenphoto
 * Zikula
 * Zimbra
-* e107
-* osDate
-* ownCloud
-* phpBB3
-* phpMyAdmin
 
 Detects following end-of-life software:
 ---------------------------------------
@@ -151,5 +152,5 @@ Happy users
 
 * DevNet Oy
 * Kapsi Internet-käyttäjät ry
-* Shellit.org
 * Loopia.se
+* Shellit.org

--- a/yamls/oscommerce.yml
+++ b/yamls/oscommerce.yml
@@ -4,7 +4,7 @@
 # OSVDB 112349 2.3.4    http://osvdb.org/show/osvdb/112349
 # OSVDB 112353 2.3.4    http://osvdb.org/show/osvdb/112353
 # OSVDB 112360 2.3.4    http://osvdb.org/show/osvdb/112360
-osCommerce (2.3):
+osCommerce 2.3:
   1:
     location: ['/includes/version.php']
     secure_version: '2.3.5'
@@ -12,7 +12,7 @@ osCommerce (2.3):
     cve: 'https://www.exploit-db.com/exploits/34582/'
     fingerprint: detect_general
     post_processing: ['php5.fcgi']
-osCommerce (2.2):
+osCommerce 2.2:
   1:
     location: ['/admin/includes/application_top.php']
     secure_version: '2.3.5'

--- a/yamls/oscommerce.yml
+++ b/yamls/oscommerce.yml
@@ -1,0 +1,22 @@
+# osCommerce http://www.oscommerce.com/
+# CVE-2014-XXXX 2.3.4   https://www.exploit-db.com/exploits/34582/
+# OSVDB 112348 2.3.4    http://osvdb.org/show/osvdb/112348
+# OSVDB 112349 2.3.4    http://osvdb.org/show/osvdb/112349
+# OSVDB 112353 2.3.4    http://osvdb.org/show/osvdb/112353
+# OSVDB 112360 2.3.4    http://osvdb.org/show/osvdb/112360
+osCommerce (2.3):
+  1:
+    location: ['/includes/version.php']
+    secure_version: '2.3.5'
+    regexp: ['(?P<version>2\.3(\.[0-9.]+)?)']
+    cve: 'https://www.exploit-db.com/exploits/34582/'
+    fingerprint: detect_general
+    post_processing: ['php5.fcgi']
+osCommerce (2.2):
+  1:
+    location: ['/admin/includes/application_top.php']
+    secure_version: '2.3.5'
+    regexp: ['\s+define.*?PROJECT_VERSION.*?(?P<version>2(\.[0-2.]+))']
+    cve: 'https://www.exploit-db.com/exploits/34582/'
+    fingerprint: detect_general
+    post_processing: ['php5.fcgi']


### PR DESCRIPTION
Version 2.3.5(?) is not available and the vulnerability has been available since 2014-09-08. Not sure how to write "secure_version" in this case. Any ideas @fgeek ? :)