### PR TITLE
Made the version for python 2 and pip 2 explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Installation
 ------------
 
     git clone https://github.com/fgeek/pyfiscan.git && cd pyfiscan
-    pip install -r requirements.lst
+    pip2 install -r requirements.lst
 
 Notes
 -----

--- a/pyfiscan.py
+++ b/pyfiscan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # -*- coding: utf-8 -*-
 
 """


### PR DESCRIPTION
I've changed the name of the python and pip executable to be python2 and pip2 so that distributions with python3 as default python can run this without editing anything