### PR TITLE
Update WP Plugin Duplicator

### DIFF
--- a/yamls/wordpress-plugins.yml
+++ b/yamls/wordpress-plugins.yml
@@ -629,12 +629,13 @@ WordPress plugin woocommerce-store-toolkit:
     cve: 'http://seclists.org/bugtraq/2016/Feb/57'
     fingerprint: detect_general
     post_processing: ['php5.fcgi']
+# 1.1.4 http://www.ratiosec.com/2016/duplicator-wordpress-plugin-source-database-disclosure-via-csrf/
 WordPress plugin duplicator:
   1:
     location: ['/wp-content/plugins/duplicator/readme.txt']
-    secure_version: '1.1.4'
+    secure_version: '1.3.28'
     regexp: ['Stable tag: (?P<version>[0-9.]{1,})']
-    cve: 'http://www.ratiosec.com/2016/duplicator-wordpress-plugin-source-database-disclosure-via-csrf/'  # CVE requested by advisory creator
+    cve: 'https://www.wordfence.com/blog/2020/02/active-attack-on-recently-patched-duplicator-plugin-vulnerability-affects-over-1-million-sites/ https://wpvulndb.com/vulnerabilities/10078'
     fingerprint: detect_general
     post_processing: ['php5.fcgi']
 WordPress plugin csv-import:


### PR DESCRIPTION
Update version for Wordpress plugin Duplicator.
Please validate it.
- [Duplicator < 1.3.28 - Unauthenticated Arbitrary File Download](https://wpvulndb.com/vulnerabilities/10078)