### PR TITLE
Added support for WordPress plugin seo-by-rank-math

### DIFF
--- a/yamls/wordpress-plugins.yml
+++ b/yamls/wordpress-plugins.yml
@@ -2972,3 +2972,11 @@ WordPress plugin responsive-add-ons:
     cve: 'https://www.wordfence.com/blog/2020/03/severe-flaws-patched-in-responsive-ready-sites-importer-plugin/'  # TODO: CVE request needed
     fingerprint: detect_general
     post_processing: ['php5.fcgi']
+WordPress plugin seo-by-rank-math:
+  1:
+    location: ['/wp-content/plugins/seo-by-rank-math/readme.txt']
+    secure_version: '1.0.41'
+    regexp: ['Stable tag: (?P<version>[0-9.]{1,})']
+    cve: 'https://www.wordfence.com/blog/2020/03/critical-vulnerabilities-affecting-over-200000-sites-patched-in-rank-math-seo-plugin/'
+    fingerprint: detect_general
+    post_processing: ['php5.fcgi']


### PR DESCRIPTION
Support for seo-by-rank-math.
Please validate it.

- [Critical Vulnerabilities Affecting Over 200,000 Sites Patched in Rank Math SEO Plugin](https://www.wordfence.com/blog/2020/03/critical-vulnerabilities-affecting-over-200000-sites-patched-in-rank-math-seo-plugin/)
- [WordPress SEO Plugin - Rank Math < 1.0.41 - Privilege Escalation via Unprotected REST API Endpoint](https://wpvulndb.com/vulnerabilities/10157)
- [WordPress SEO Plugin - Rank Math < 1.0.41 - Redirect Creation via Unprotected REST API Endpoint](https://wpvulndb.com/vulnerabilities/10158)