### PR TITLE
Add CVE information for WordPress plugin duplicator

### DIFF
--- a/yamls/wordpress-plugins.yml
+++ b/yamls/wordpress-plugins.yml
@@ -635,7 +635,7 @@ WordPress plugin duplicator:
     location: ['/wp-content/plugins/duplicator/readme.txt']
     secure_version: '1.3.28'
     regexp: ['Stable tag: (?P<version>[0-9.]{1,})']
-    cve: 'https://www.wordfence.com/blog/2020/02/active-attack-on-recently-patched-duplicator-plugin-vulnerability-affects-over-1-million-sites/ https://wpvulndb.com/vulnerabilities/10078'
+    cve: 'https://nvd.nist.gov/vuln/detail/CVE-2020-11738 https://www.wordfence.com/blog/2020/02/active-attack-on-recently-patched-duplicator-plugin-vulnerability-affects-over-1-million-sites/ https://wpvulndb.com/vulnerabilities/10078'
     fingerprint: detect_general
     post_processing: ['php5.fcgi']
 WordPress plugin csv-import:


### PR DESCRIPTION
The duplicator vulnerability CVE is "CVE-2020-11738".
Please validate it.
- [NVD - CVE-2020-11738](https://nvd.nist.gov/vuln/detail/CVE-2020-11738)