### PR TITLE
Added support for WordPress plugin duplicate-wp-page-post

### DIFF
--- a/yamls/wordpress-plugins.yml
+++ b/yamls/wordpress-plugins.yml
@@ -3004,3 +3004,11 @@ WordPress plugin mappress-google-maps-for-wordpress:
     cve: 'https://nvd.nist.gov/vuln/detail/CVE-2020-12077 https://www.wordfence.com/blog/2020/04/critical-vulnerabilities-patched-in-mappress-maps-plugin/'
     fingerprint: detect_general
     post_processing: ['php5.fcgi']
+WordPress plugin duplicate-wp-page-post:
+  1:
+    location: ['/wp-content/plugins/duplicate-wp-page-post/readme.txt']
+    secure_version: '2.5.7'
+    regexp: ['Stable tag: (?P<version>[0-9.]{1,})']
+    cve: 'https://blog.sucuri.net/2020/04/duplicated-vulnerabilities-in-wordpress-plugins.html https://wpvulndb.com/vulnerabilities/10190'
+    fingerprint: detect_general
+    post_processing: ['php5.fcgi']


### PR DESCRIPTION
## References
- [Duplicated Vulnerabilities in WordPress Plugins](https://blog.sucuri.net/2020/04/duplicated-vulnerabilities-in-wordpress-plugins.html)
- [Duplicate Page and Post < 2.5.7 & WP Post Page Clone - SQL Injections due to Duplicated Snippets](https://wpvulndb.com/vulnerabilities/10190)